### PR TITLE
HTTP2 Ignore Headers

### DIFF
--- a/http2/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Connection.java
+++ b/http2/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Connection.java
@@ -138,9 +138,7 @@ public class HTTP2Connection {
                 for (JMeterProperty prop : headersProps) {
                     Header header = (Header) prop.getObjectValue();
                     String n = header.getName();
-                    // Don't allow override of Content-Length
-                    // TODO - what other headers are not allowed?
-                    if(n.contains(":")){
+                    if(n.startsWith(":")){
                         LOG.warn("The specified pseudo header {} is not allowed "
                             + "and will be ignored", n);
                     }


### PR DESCRIPTION
Changed the condition to only ignore and log pseudo headers, and let onReset handle other cases of invalid headers.